### PR TITLE
Submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-react": "^6.5.0",
     "fetch-jsonp": "^1.0.0",
+    "lodash": "^4.16.1",
     "moment": "^2.13.0",
     "react": "^15.0.2",
     "react-dom": "^15.0.2",

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -1,5 +1,6 @@
 import fetch from 'fetch-jsonp'
 import moment from 'moment'
+import { uniq } from 'lodash'
 
 export function getPopularMovies () {
   return dispatch => {
@@ -35,11 +36,28 @@ export function getPopularMovies () {
             longDescription: movie.longDescription,
             trackName: movie.trackName,
           }
-        })
+        });
 
-        combinedResults.sort((a,b) => {
-          return b.releaseYear - a.releaseYear;
-        })
+
+        const years = uniq(combinedResults.map(movie => movie.releaseYear));
+
+        years.sort().reverse();
+
+        // object preserving order
+        
+        const yearBuckets = {};
+
+        years.forEach(year => {
+          yearBuckets[year] = [];
+        });
+
+        combinedResults.forEach(movie => {
+          yearBuckets[movie.releaseYear].push(movie);
+        });
+
+        console.log(yearBuckets)
+
+        
         //
         // 1. combine the results of these requests
         // 2. sort the results FIRST by year THEN by title (trackName)

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -30,14 +30,16 @@ export function getPopularMovies () {
         const combinedResults = fullList.map(movie => {
           return {
             artworkUrl100: movie.artworkUrl100,
-            releaseYear: movie.releaseYear,
+            releaseYear: movie.releaseDate.split('-')[0],
             trackHdPrice: movie.trackHdPrice,
-            longDescription: movie.longDescription
+            longDescription: movie.longDescription,
+            trackName: movie.trackName,
           }
         })
 
-        console.log(combinedResults)
-
+        combinedResults.sort((a,b) => {
+          return b.releaseYear - a.releaseYear;
+        })
         //
         // 1. combine the results of these requests
         // 2. sort the results FIRST by year THEN by title (trackName)

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -17,17 +17,18 @@ export function getPopularMovies () {
         // jsonResponses contains the results of two API requests
         //
 
-        //check error
-        console.log(jsonResponses)
+        //
+        // 1. combine the results of these requests
+        // 2. sort the results FIRST by year THEN by title (trackName)
+        // 3. each movie object in the results needs a releaseYear attribute added
+        //    this is used in src/components/movies-list.js line 26
+        //
 
-       /* <td><img src={movie.artworkUrl100} /></td>
-        <td>{movie.releaseYear}</td>
-        <td>{movie.trackName}</td>
-        <td>{`$${movie.trackHdPrice}`}</td>
-        <td>{movie.longDescription}</td> */
-
+        // combine both array lists
         const fullList = [...jsonResponses[0].results, ...jsonResponses[1].results];
 
+        // extract relevant fields from movie objects, and move 'The' to end of title 
+        // if it appears
         let combinedResults = fullList.map(movie => {
 
           let splitTrackName = movie.trackName.split(' ');
@@ -47,41 +48,30 @@ export function getPopularMovies () {
           }
         });
 
-
+        // create descending array of unique movie years
         const years = uniq(combinedResults.map(movie => movie.releaseYear));
-
         years.sort().reverse();
-
-        // object preserving order
         
+        // create object where keys are each movie year, with arrays to hold movies
+        // of that year
         const yearBuckets = {};
-
         years.forEach(year => {
           yearBuckets[year] = [];
         });
 
+        // add movie to proper year
         combinedResults.forEach(movie => {
           yearBuckets[movie.releaseYear].push(movie);
         });
 
+        // sort each year bucket but the track name
         for (let key in yearBuckets) {
           yearBuckets[key] = sortBy(yearBuckets[key], ['trackName']);
         }
 
-        // preserve proper year order
+        // combine buckets, preserving proper year order, and flatten array
         combinedResults = flattenDeep(years.map(year => yearBuckets[year]));
-
-        console.log(combinedResults)
-        
-        //
-        // 1. combine the results of these requests
-        // 2. sort the results FIRST by year THEN by title (trackName)
-        // 3. each movie object in the results needs a releaseYear attribute added
-        //    this is used in src/components/movies-list.js line 26
-        //
-
-        // const combinedResults = []
-
+      
         return dispatch({
           type: 'GET_MOVIES_SUCCESS',
           movies: combinedResults

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -16,6 +16,28 @@ export function getPopularMovies () {
         // jsonResponses contains the results of two API requests
         //
 
+        //check error
+        console.log(jsonResponses)
+
+       /* <td><img src={movie.artworkUrl100} /></td>
+        <td>{movie.releaseYear}</td>
+        <td>{movie.trackName}</td>
+        <td>{`$${movie.trackHdPrice}`}</td>
+        <td>{movie.longDescription}</td> */
+
+        const fullList = [...jsonResponses[0].results, ...jsonResponses[1].results];
+
+        const combinedResults = fullList.map(movie => {
+          return {
+            artworkUrl100: movie.artworkUrl100,
+            releaseYear: movie.releaseYear,
+            trackHdPrice: movie.trackHdPrice,
+            longDescription: movie.longDescription
+          }
+        })
+
+        console.log(combinedResults)
+
         //
         // 1. combine the results of these requests
         // 2. sort the results FIRST by year THEN by title (trackName)
@@ -23,7 +45,7 @@ export function getPopularMovies () {
         //    this is used in src/components/movies-list.js line 26
         //
 
-        const combinedResults = []
+        // const combinedResults = []
 
         return dispatch({
           type: 'GET_MOVIES_SUCCESS',


### PR DESCRIPTION
When merged, the getPopularMovies function will display all movies sorted by descending year and within a year the movies are sorted alphabetically by title.

To accomplish this a series of transformations are done to the JSON response objects of two calls to the itunes API.

1. The results are spread and combined into a single array
2. The combined array is mapped over extracting the relevant fields. Also if a title of a film starts with _The_ it is moved to the end of the title (e.g. _The Boss_ becomes _Boss, The_)
3. An array of each year in descending order is created
4. An object where the keys are each year and their values are empty array buckets is created
5. The combined results array is looped through placing each movie into the proper bucked in the object. This is done so that ordering of years can happen alphabetically independent of year.
6. Each year bucket is then sorted by _trackName_ and then combined in order and flattened to a 1D array.

**Note**
`npm install` will be required as lodash was added for simplifying operations on collections.
